### PR TITLE
Fix/humanoid continuous interpolation

### DIFF
--- a/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.asset
+++ b/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 55
+      Data: 58
     - Name: 
       Entry: 7
       Data: 
@@ -2606,19 +2606,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _hasContinuousBoneTargets
+      Data: _receivedAncestorBoneIdsById
     - Name: $v
       Entry: 7
       Data: 131|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _hasContinuousBoneTargets
+      Data: _receivedAncestorBoneIdsById
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 43
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 43
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2655,13 +2655,13 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _hasContinuousRootTarget
+      Data: _receivedAncestorBoneIdsValid
     - Name: $v
       Entry: 7
       Data: 133|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _hasContinuousRootTarget
+      Data: _receivedAncestorBoneIdsValid
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 51
@@ -2704,19 +2704,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _continuousRootIsLocal
+      Data: _receivedAncestorBoneIdsHash
     - Name: $v
       Entry: 7
       Data: 135|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _continuousRootIsLocal
+      Data: _receivedAncestorBoneIdsHash
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 3
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 3
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2753,25 +2753,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _continuousRootPosition
+      Data: _hasContinuousBoneTargets
     - Name: $v
       Entry: 7
       Data: 137|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _continuousRootPosition
+      Data: _hasContinuousBoneTargets
     - Name: <UserType>k__BackingField
-      Entry: 7
-      Data: 138|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: UnityEngine.Vector3, UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 51
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 138
+      Data: 51
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2786,7 +2780,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 139|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 138|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
@@ -2808,25 +2802,68 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _continuousRootRotation
+      Data: _hasContinuousRootTarget
     - Name: $v
       Entry: 7
-      Data: 140|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 139|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _continuousRootRotation
+      Data: _hasContinuousRootTarget
     - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 51
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 51
+    - Name: <SyncMode>k__BackingField
       Entry: 7
-      Data: 141|System.RuntimeType, mscorlib
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
     - Name: 
-      Entry: 1
-      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+      Entry: 6
+      Data: 
     - Name: 
       Entry: 8
       Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 140|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _continuousRootIsLocal
+    - Name: $v
+      Entry: 7
+      Data: 141|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _continuousRootIsLocal
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 51
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 141
+      Data: 51
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2863,10 +2900,120 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _continuousRootHasRotation
+      Data: _continuousRootPosition
     - Name: $v
       Entry: 7
       Data: 143|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _continuousRootPosition
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 144|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 144
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 145|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _continuousRootRotation
+    - Name: $v
+      Entry: 7
+      Data: 146|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _continuousRootRotation
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 147|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 147
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 148|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _continuousRootHasRotation
+    - Name: $v
+      Entry: 7
+      Data: 149|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _continuousRootHasRotation
@@ -2890,7 +3037,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 144|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 150|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12

--- a/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.asset
+++ b/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: TSMPNetworkHumanoidPoseSync
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: 23f12314e9f82e542a72e81358a95f9f,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: bc1cf9fe325995b4a91c53b9dd9776b9,
     type: 2}
   udonAssembly: 
   assemblyError: 
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 53
+      Data: 55
     - Name: 
       Entry: 7
       Data: 
@@ -2459,19 +2459,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _targetBoneRotationIsLocal
+      Data: _receivedBoneWorldRotations
     - Name: $v
       Entry: 7
       Data: 125|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _targetBoneRotationIsLocal
+      Data: _receivedBoneWorldRotations
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 75
+      Data: 121
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 75
+      Data: 121
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2508,19 +2508,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _hasContinuousBoneTargets
+      Data: _hasReceivedBoneWorldRotation
     - Name: $v
       Entry: 7
       Data: 127|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _hasContinuousBoneTargets
+      Data: _hasReceivedBoneWorldRotation
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 75
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 75
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2557,19 +2557,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _hasContinuousRootTarget
+      Data: _boneParentIdsById
     - Name: $v
       Entry: 7
       Data: 129|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _hasContinuousRootTarget
+      Data: _boneParentIdsById
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 43
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 51
+      Data: 43
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2606,13 +2606,13 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _continuousRootIsLocal
+      Data: _hasContinuousBoneTargets
     - Name: $v
       Entry: 7
       Data: 131|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: _continuousRootIsLocal
+      Data: _hasContinuousBoneTargets
     - Name: <UserType>k__BackingField
       Entry: 9
       Data: 51
@@ -2655,16 +2655,114 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: _continuousRootPosition
+      Data: _hasContinuousRootTarget
     - Name: $v
       Entry: 7
       Data: 133|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
+      Data: _hasContinuousRootTarget
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 51
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 51
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 134|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _continuousRootIsLocal
+    - Name: $v
+      Entry: 7
+      Data: 135|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _continuousRootIsLocal
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 51
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 51
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 136|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _continuousRootPosition
+    - Name: $v
+      Entry: 7
+      Data: 137|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
       Data: _continuousRootPosition
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 134|System.RuntimeType, mscorlib
+      Data: 138|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Vector3, UnityEngine.CoreModule
@@ -2673,7 +2771,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 134
+      Data: 138
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2688,7 +2786,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 135|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 139|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
@@ -2713,13 +2811,13 @@ MonoBehaviour:
       Data: _continuousRootRotation
     - Name: $v
       Entry: 7
-      Data: 136|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 140|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _continuousRootRotation
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 137|System.RuntimeType, mscorlib
+      Data: 141|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Quaternion, UnityEngine.CoreModule
@@ -2728,7 +2826,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 137
+      Data: 141
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -2743,7 +2841,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 138|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 142|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
@@ -2768,7 +2866,7 @@ MonoBehaviour:
       Data: _continuousRootHasRotation
     - Name: $v
       Entry: 7
-      Data: 139|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 143|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: _continuousRootHasRotation
@@ -2792,7 +2890,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 140|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 144|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12

--- a/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.cs
+++ b/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.cs
@@ -126,6 +126,9 @@ namespace K13A.TSMP.Udon
         private Quaternion[] _receivedBoneWorldRotations;
         private bool[] _hasReceivedBoneWorldRotation;
         private int[] _boneParentIdsById;
+        private int[] _receivedAncestorBoneIdsById;
+        private bool _receivedAncestorBoneIdsValid;
+        private int _receivedAncestorBoneIdsHash;
         private bool _hasContinuousBoneTargets;
         private bool _hasContinuousRootTarget;
         private bool _continuousRootIsLocal;
@@ -630,6 +633,7 @@ namespace K13A.TSMP.Udon
 
             int hips = (int)HumanBodyBones.Hips;
             int count = _hasReceivedBoneWorldRotation.Length;
+            EnsureReceivedAncestorBoneIdsCache();
             for (int i = 0; i < count; i++)
             {
                 if (!_hasReceivedBoneWorldRotation[i])
@@ -658,8 +662,19 @@ namespace K13A.TSMP.Udon
 
         private Quaternion GetContinuousParentWorldRotation(int boneId, Transform parent)
         {
-            int ancestorBoneId = FindReceivedAncestorBoneId(boneId);
-            if (ancestorBoneId >= 0 && _boneTargetsById != null && ancestorBoneId < _boneTargetsById.Length && _receivedBoneWorldRotations != null)
+            int ancestorBoneId = -1;
+            if (_receivedAncestorBoneIdsById != null && boneId >= 0 && boneId < _receivedAncestorBoneIdsById.Length)
+                ancestorBoneId = _receivedAncestorBoneIdsById[boneId];
+
+            bool ancestorAvailable = ancestorBoneId >= 0
+                                     && _boneTargetsById != null
+                                     && _receivedBoneWorldRotations != null
+                                     && _hasReceivedBoneWorldRotation != null
+                                     && ancestorBoneId < _boneTargetsById.Length
+                                     && ancestorBoneId < _receivedBoneWorldRotations.Length
+                                     && ancestorBoneId < _hasReceivedBoneWorldRotation.Length
+                                     && _hasReceivedBoneWorldRotation[ancestorBoneId];
+            if (ancestorAvailable)
             {
                 Transform ancestor = _boneTargetsById[ancestorBoneId];
                 if (ancestor != null)
@@ -667,6 +682,40 @@ namespace K13A.TSMP.Udon
             }
 
             return parent.rotation;
+        }
+
+        private void EnsureReceivedAncestorBoneIdsCache()
+        {
+            if (_receivedAncestorBoneIdsById == null || _hasReceivedBoneWorldRotation == null)
+                return;
+
+            int hash = ComputeReceivedBoneWorldRotationHash();
+            if (_receivedAncestorBoneIdsValid && _receivedAncestorBoneIdsHash == hash)
+                return;
+
+            _receivedAncestorBoneIdsHash = hash;
+            _receivedAncestorBoneIdsValid = true;
+
+            int count = _receivedAncestorBoneIdsById.Length;
+            for (int i = 0; i < count; i++)
+                _receivedAncestorBoneIdsById[i] = FindReceivedAncestorBoneId(i);
+        }
+
+        private int ComputeReceivedBoneWorldRotationHash()
+        {
+            if (_hasReceivedBoneWorldRotation == null)
+                return 0;
+
+            int hash = 17;
+            int count = _hasReceivedBoneWorldRotation.Length;
+            hash = hash * 31 + count;
+            for (int i = 0; i < count; i++)
+            {
+                if (_hasReceivedBoneWorldRotation[i])
+                    hash = hash * 31 + i;
+            }
+
+            return hash;
         }
 
         private int FindReceivedAncestorBoneId(int boneId)
@@ -769,6 +818,13 @@ namespace K13A.TSMP.Udon
                 for (int i = 0; i < lastBone; i++)
                     _boneParentIdsById[i] = -1;
             }
+            if (_receivedAncestorBoneIdsById == null || _receivedAncestorBoneIdsById.Length != lastBone)
+            {
+                _receivedAncestorBoneIdsById = new int[lastBone];
+                for (int i = 0; i < lastBone; i++)
+                    _receivedAncestorBoneIdsById[i] = -1;
+                _receivedAncestorBoneIdsValid = false;
+            }
             if (boneIds != null && (_activeBoneIndices == null || _activeBoneIndices.Length != boneIds.Length))
                 _activeBoneIndices = new int[boneIds.Length];
             if (boneIds != null && (_activeBoneIds == null || _activeBoneIds.Length != boneIds.Length))
@@ -849,6 +905,8 @@ namespace K13A.TSMP.Udon
                     parent = parent.parent;
                 }
             }
+
+            _receivedAncestorBoneIdsValid = false;
         }
 
         private int FindBoneIdByTransform(Transform target)

--- a/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.cs
+++ b/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.cs
@@ -123,7 +123,9 @@ namespace K13A.TSMP.Udon
         private bool _fingerBoneIdsPreparedInclude;
         private Quaternion[] _targetBoneRotations;
         private bool[] _hasTargetBoneRotation;
-        private bool[] _targetBoneRotationIsLocal;
+        private Quaternion[] _receivedBoneWorldRotations;
+        private bool[] _hasReceivedBoneWorldRotation;
+        private int[] _boneParentIdsById;
         private bool _hasContinuousBoneTargets;
         private bool _hasContinuousRootTarget;
         private bool _continuousRootIsLocal;
@@ -287,6 +289,12 @@ namespace K13A.TSMP.Udon
 
             Transform[] targetsById = _boneTargetsById;
             bool continuous = receiveInterpolation == ReceiveInterpolationMode.Continuous;
+            if (continuous)
+            {
+                EnsureLookupArrays();
+                targetsById = _boneTargetsById;
+                ClearReceivedBoneWorldRotations();
+            }
 
             for (int i = 0; i < count; i++)
             {
@@ -311,26 +319,23 @@ namespace K13A.TSMP.Udon
 
                 if (continuous)
                 {
-                    if (_targetBoneRotations != null && _hasTargetBoneRotation != null && _targetBoneRotationIsLocal != null && rawBoneId < _targetBoneRotations.Length)
+                    if (_targetBoneRotations != null && _hasTargetBoneRotation != null && rawBoneId < _targetBoneRotations.Length)
                     {
-                        if (animatorRootSpaceRotations && animatorRoot != null)
-                        {
-                            _targetBoneRotations[rawBoneId] = animatorRootRotation * rotation;
-                            _targetBoneRotationIsLocal[rawBoneId] = false;
-                        }
-                        else if (localRotations)
+                        if (localRotations)
                         {
                             _targetBoneRotations[rawBoneId] = rotation;
-                            _targetBoneRotationIsLocal[rawBoneId] = true;
+                            _hasTargetBoneRotation[rawBoneId] = true;
+                            _hasContinuousBoneTargets = true;
                         }
-                        else
+                        else if (_receivedBoneWorldRotations != null && _hasReceivedBoneWorldRotation != null && rawBoneId < _receivedBoneWorldRotations.Length)
                         {
-                            _targetBoneRotations[rawBoneId] = rotation;
-                            _targetBoneRotationIsLocal[rawBoneId] = false;
-                        }
+                            if (animatorRootSpaceRotations && animatorRoot != null)
+                                _receivedBoneWorldRotations[rawBoneId] = animatorRootRotation * rotation;
+                            else
+                                _receivedBoneWorldRotations[rawBoneId] = rotation;
 
-                        _hasTargetBoneRotation[rawBoneId] = true;
-                        _hasContinuousBoneTargets = true;
+                            _hasReceivedBoneWorldRotation[rawBoneId] = true;
+                        }
                     }
                 }
                 else if (animatorRootSpaceRotations && animatorRoot != null)
@@ -347,6 +352,7 @@ namespace K13A.TSMP.Udon
                 }
             }
 
+            bool skipContinuousRootBoneRotation = false;
             if (version >= 2 && (flags & PoseFlagHasRootMotionPosition) != 0 && cursor + PoseRootMotionPositionBytes <= poseBytes.Length)
             {
                 Vector3 rootPosition = Binary.ReadVector3Float32LE(poseBytes, cursor);
@@ -370,6 +376,11 @@ namespace K13A.TSMP.Udon
                         _continuousRootIsLocal = false;
                         _continuousRootHasRotation = hasRootRotation;
                         _hasContinuousRootTarget = true;
+                        if (hasRootRotation)
+                        {
+                            SetReceivedRootWorldRotation(target, rootRotation, false);
+                            skipContinuousRootBoneRotation = true;
+                        }
                     }
                     else
                     {
@@ -388,6 +399,11 @@ namespace K13A.TSMP.Udon
                         _continuousRootIsLocal = false;
                         _continuousRootHasRotation = hasRootRotation;
                         _hasContinuousRootTarget = true;
+                        if (hasRootRotation)
+                        {
+                            SetReceivedRootWorldRotation(target, _continuousRootRotation, false);
+                            skipContinuousRootBoneRotation = true;
+                        }
                     }
                     else
                     {
@@ -405,6 +421,11 @@ namespace K13A.TSMP.Udon
                         _continuousRootIsLocal = true;
                         _continuousRootHasRotation = hasRootRotation;
                         _hasContinuousRootTarget = true;
+                        if (hasRootRotation)
+                        {
+                            SetReceivedRootWorldRotation(target, rootRotation, true);
+                            skipContinuousRootBoneRotation = true;
+                        }
                     }
                     else
                     {
@@ -414,6 +435,9 @@ namespace K13A.TSMP.Udon
                     }
                 }
             }
+
+            if (continuous)
+                ConvertReceivedWorldRotationsToLocalTargets(skipContinuousRootBoneRotation);
         }
 
         public override void OnTSMPVariableReceived()
@@ -479,6 +503,7 @@ namespace K13A.TSMP.Udon
             }
 
             _rootMotionTarget = _boneTargetsById[(int)HumanBodyBones.Hips];
+            RebuildBoneParentLookup();
             RebuildActiveBoneIndices();
             _resolvedAnimator = animator;
             _resolvedBones = true;
@@ -570,6 +595,103 @@ namespace K13A.TSMP.Udon
             return HumanoidBoneUtil.HasBoneId(_hasBoneId, boneId);
         }
 
+        private void ClearReceivedBoneWorldRotations()
+        {
+            if (_hasReceivedBoneWorldRotation == null)
+                return;
+
+            int count = _hasReceivedBoneWorldRotation.Length;
+            for (int i = 0; i < count; i++)
+                _hasReceivedBoneWorldRotation[i] = false;
+        }
+
+        private void SetReceivedRootWorldRotation(Transform root, Quaternion rootRotation, bool rootRotationIsLocal)
+        {
+            int hips = (int)HumanBodyBones.Hips;
+            if (root == null || _receivedBoneWorldRotations == null || _hasReceivedBoneWorldRotation == null || hips >= _receivedBoneWorldRotations.Length)
+                return;
+
+            Quaternion worldRotation = rootRotation;
+            if (rootRotationIsLocal)
+            {
+                Transform parent = root.parent;
+                if (parent != null)
+                    worldRotation = parent.rotation * rootRotation;
+            }
+
+            _receivedBoneWorldRotations[hips] = worldRotation;
+            _hasReceivedBoneWorldRotation[hips] = true;
+        }
+
+        private void ConvertReceivedWorldRotationsToLocalTargets(bool skipRootBoneRotation)
+        {
+            if (_receivedBoneWorldRotations == null || _hasReceivedBoneWorldRotation == null || _targetBoneRotations == null || _hasTargetBoneRotation == null || _boneTargetsById == null)
+                return;
+
+            int hips = (int)HumanBodyBones.Hips;
+            int count = _hasReceivedBoneWorldRotation.Length;
+            for (int i = 0; i < count; i++)
+            {
+                if (!_hasReceivedBoneWorldRotation[i])
+                    continue;
+
+                if (skipRootBoneRotation && i == hips)
+                {
+                    _hasTargetBoneRotation[i] = false;
+                    continue;
+                }
+
+                Transform target = i < _boneTargetsById.Length ? _boneTargetsById[i] : null;
+                if (target == null)
+                    continue;
+
+                Transform parent = target.parent;
+                Quaternion parentWorldRotation = Quaternion.identity;
+                if (parent != null)
+                    parentWorldRotation = GetContinuousParentWorldRotation(i, parent);
+
+                _targetBoneRotations[i] = Quaternion.Inverse(parentWorldRotation) * _receivedBoneWorldRotations[i];
+                _hasTargetBoneRotation[i] = true;
+                _hasContinuousBoneTargets = true;
+            }
+        }
+
+        private Quaternion GetContinuousParentWorldRotation(int boneId, Transform parent)
+        {
+            int ancestorBoneId = FindReceivedAncestorBoneId(boneId);
+            if (ancestorBoneId >= 0 && _boneTargetsById != null && ancestorBoneId < _boneTargetsById.Length && _receivedBoneWorldRotations != null)
+            {
+                Transform ancestor = _boneTargetsById[ancestorBoneId];
+                if (ancestor != null)
+                    return _receivedBoneWorldRotations[ancestorBoneId] * Quaternion.Inverse(ancestor.rotation) * parent.rotation;
+            }
+
+            return parent.rotation;
+        }
+
+        private int FindReceivedAncestorBoneId(int boneId)
+        {
+            if (_boneParentIdsById == null || _hasReceivedBoneWorldRotation == null)
+                return -1;
+
+            int lastBone = _boneParentIdsById.Length;
+            int parentBoneId = -1;
+            if (boneId >= 0 && boneId < lastBone)
+                parentBoneId = _boneParentIdsById[boneId];
+
+            int guard = 0;
+            while (parentBoneId >= 0 && parentBoneId < lastBone && guard < lastBone)
+            {
+                if (parentBoneId < _hasReceivedBoneWorldRotation.Length && _hasReceivedBoneWorldRotation[parentBoneId])
+                    return parentBoneId;
+
+                parentBoneId = _boneParentIdsById[parentBoneId];
+                guard++;
+            }
+
+            return -1;
+        }
+
         private void ApplyContinuousPose()
         {
             if (receiveInterpolation != ReceiveInterpolationMode.Continuous || !IsTSMPActive())
@@ -577,7 +699,7 @@ namespace K13A.TSMP.Udon
 
             float step = GetReceiveInterpolationStep();
             bool hasBoneTargets = false;
-            if (_hasContinuousBoneTargets && _hasTargetBoneRotation != null && _targetBoneRotations != null && _targetBoneRotationIsLocal != null && _boneTargetsById != null)
+            if (_hasContinuousBoneTargets && _hasTargetBoneRotation != null && _targetBoneRotations != null && _boneTargetsById != null)
             {
                 int count = _hasTargetBoneRotation.Length;
                 for (int i = 0; i < count; i++)
@@ -590,10 +712,7 @@ namespace K13A.TSMP.Udon
                         continue;
 
                     Quaternion targetRotation = _targetBoneRotations[i];
-                    if (_targetBoneRotationIsLocal[i])
-                        target.localRotation = Quaternion.Slerp(target.localRotation, targetRotation, step);
-                    else
-                        target.rotation = Quaternion.Slerp(target.rotation, targetRotation, step);
+                    target.localRotation = Quaternion.Slerp(target.localRotation, targetRotation, step);
 
                     hasBoneTargets = true;
                 }
@@ -640,8 +759,16 @@ namespace K13A.TSMP.Udon
                 _targetBoneRotations = new Quaternion[lastBone];
             if (_hasTargetBoneRotation == null || _hasTargetBoneRotation.Length != lastBone)
                 _hasTargetBoneRotation = new bool[lastBone];
-            if (_targetBoneRotationIsLocal == null || _targetBoneRotationIsLocal.Length != lastBone)
-                _targetBoneRotationIsLocal = new bool[lastBone];
+            if (_receivedBoneWorldRotations == null || _receivedBoneWorldRotations.Length != lastBone)
+                _receivedBoneWorldRotations = new Quaternion[lastBone];
+            if (_hasReceivedBoneWorldRotation == null || _hasReceivedBoneWorldRotation.Length != lastBone)
+                _hasReceivedBoneWorldRotation = new bool[lastBone];
+            if (_boneParentIdsById == null || _boneParentIdsById.Length != lastBone)
+            {
+                _boneParentIdsById = new int[lastBone];
+                for (int i = 0; i < lastBone; i++)
+                    _boneParentIdsById[i] = -1;
+            }
             if (boneIds != null && (_activeBoneIndices == null || _activeBoneIndices.Length != boneIds.Length))
                 _activeBoneIndices = new int[boneIds.Length];
             if (boneIds != null && (_activeBoneIds == null || _activeBoneIds.Length != boneIds.Length))
@@ -692,6 +819,51 @@ namespace K13A.TSMP.Udon
             _cachedBoneIdHash = GetBoneIdHash();
             _cachedIncludeFingerBones = includeFingerBones;
             _boneCacheValid = true;
+        }
+
+        private void RebuildBoneParentLookup()
+        {
+            if (_boneParentIdsById == null || _boneTargetsById == null)
+                return;
+
+            int lastBone = _boneParentIdsById.Length;
+            for (int i = 0; i < lastBone; i++)
+                _boneParentIdsById[i] = -1;
+
+            for (int i = 0; i < lastBone; i++)
+            {
+                Transform target = i < _boneTargetsById.Length ? _boneTargetsById[i] : null;
+                if (target == null)
+                    continue;
+
+                Transform parent = target.parent;
+                while (parent != null)
+                {
+                    int parentBoneId = FindBoneIdByTransform(parent);
+                    if (parentBoneId >= 0)
+                    {
+                        _boneParentIdsById[i] = parentBoneId;
+                        break;
+                    }
+
+                    parent = parent.parent;
+                }
+            }
+        }
+
+        private int FindBoneIdByTransform(Transform target)
+        {
+            if (target == null || _boneTargetsById == null)
+                return -1;
+
+            int count = _boneTargetsById.Length;
+            for (int i = 0; i < count; i++)
+            {
+                if (_boneTargetsById[i] == target)
+                    return i;
+            }
+
+            return -1;
         }
 
         private int GetBoneIdHash()

--- a/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.cs
+++ b/Packages/com.kibalab.tsmp.core/Runtime/Network/TSMPNetworkHumanoidPoseSync.cs
@@ -678,7 +678,13 @@ namespace K13A.TSMP.Udon
             {
                 Transform ancestor = _boneTargetsById[ancestorBoneId];
                 if (ancestor != null)
-                    return _receivedBoneWorldRotations[ancestorBoneId] * Quaternion.Inverse(ancestor.rotation) * parent.rotation;
+                {
+                    Quaternion ancestorWorldRotation = _receivedBoneWorldRotations[ancestorBoneId];
+                    if (ancestor == parent)
+                        return ancestorWorldRotation;
+
+                    return ancestorWorldRotation * Quaternion.Inverse(ancestor.rotation) * parent.rotation;
+                }
             }
 
             return parent.rotation;


### PR DESCRIPTION
HumanoidのReceive Interpolation: Continuousによる回転の補間をLocal Spaceで行うよう修正したいです。

TSMPNetworkHumanoidPoseSyncのReceive InterpolationをContinuousにした際、末端側のボーンから先に目標姿勢へ収束する問題があります。
例えばUpperArmを回転させた場合、手が先に目標位置へ到達し、肘が遅れて追従するように見えることがありました。

Continuousでは、受信した各ボーンの回転をワールド回転に変換し、それぞれ独立してQuaternion.Slerpしていました。
子ボーンのRotationは親ボーンのRotationにも影響されるため、親子それぞれのRotationを同じ割合で補間しても、各階層は同じ割合で収束しません。
その結果、手などの末端側が先に目標へ到達し、肘などの親側が遅れて付いてくるような見た目になっていました。

Continuousで回転を受信した場合、受信姿勢をlocalRotationへ変換してから補間するように変更しました。
localRotationを同じ補間率で更新することで、より自然に目標姿勢へ収束するようになりました。

（負荷面への対応）
localRotationへの変換には、親ボーンのRotation(World Space)が必要です。
親ボーンのRotationを直接受信できている場合は、その値をそのまま使用します。
親ボーンのRotationを直接受信していない場合（Twistボーンが入っているケース等）は、親ボーンが最も近い受信済み祖先ボーンに対して現在持っている回転の差を、その祖先ボーンのRotationに適用することで、親ボーンのRotationを求めます。

受信ボーンの構成が変わらない限り祖先を毎回探索しないよう、各ボーンに対応する最も近い受信済み祖先のIDをキャッシュするようにしており、キャッシュはボーン構造が変更されたときのみ更新されます。


なお送受信するデータの形式は変更していません。